### PR TITLE
Add custom git.io short url to repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libdvdcss
+# libdvdcss (https://git.io/libdvdcss-dll)
 
 From the [website](http://www.videolan.org/developers/libdvdcss.html):
 


### PR DESCRIPTION
I created the git.io short URL `git.io/libdvdcss-dll`, which would be great to broadcast its existence in the README.